### PR TITLE
Update publication venues with full conference names and acceptance status

### DIFF
--- a/Utkarsh.html
+++ b/Utkarsh.html
@@ -211,7 +211,7 @@
           Dwip Dalal*,<strong> Utkarsh Mishra</strong>*, Nebojsa Jojic, Narendra Ahuja
           <br>
           <div style="height: 0.5em;"></div>
-          <em><strong>EACL 2026</strong> [ORAL PRESENTATION]</em> <span style="font-size: 12px; color: #666;">(*Equal contribution)</span>
+          <em><strong>European Chapter of the Association for Computational Linguistics (EACL) 2026</strong> [ORAL PRESENTATION]</em> <span style="font-size: 12px; color: #666;">(*Equal contribution)</span>
           <br>
           <a href="https://www.microsoft.com/en-us/research/publication/city-navigation-in-the-wild-exploring-emergent-navigation-from-web-scale-knowledge-in-mllms/">Paper</a> |
           <a href="https://dwipddalal.github.io/AgentNav/">Project Page</a>
@@ -227,7 +227,7 @@
           Dwip Dalal, Gautam Vashishtha,<strong> Utkarsh Mishra,</strong> ... Svetlana Lazebnik, Heng Ji, Unnat Jain
           <br>
           <div style="height: 0.5em;"></div>
-          <em>arXiv preprint, under review</em>
+          <em><strong>International Conference on Learning Representations (ICLR) 2026</strong></em>
           <br>
           <a href="https://arxiv.org/pdf/2510.09741">Paper</a> |
           <a href="https://dwipddalal.github.io/Attwarp/">Project Page</a>

--- a/index.html
+++ b/index.html
@@ -162,7 +162,7 @@
                 <br>
                 Dwip Dalal*, <b>Utkarsh Mishra*</b>, Nebojsa Jojic, Narendra Ahuja
                 <br>
-                <em><strong>EACL 2026</strong> [ORAL PRESENTATION]</em> <span style="font-size: 12px; color: #666;">(*Equal contribution)</span>
+                <em><strong>European Chapter of the Association for Computational Linguistics (EACL) 2026</strong> [ORAL PRESENTATION]</em> <span style="font-size: 12px; color: #666;">(*Equal contribution)</span>
                 <br>
                 <a href="https://www.microsoft.com/en-us/research/publication/city-navigation-in-the-wild-exploring-emergent-navigation-from-web-scale-knowledge-in-mllms/">Paper</a> |
                 <a href="https://dwipddalal.github.io/AgentNav/">Project Page</a>
@@ -182,7 +182,7 @@
                 <br>
                 D. Dalal, G. Vashishtha, <b>Utkarsh Mishra</b>, J. Kim, M. Kanda, H. Ha, Svetlana Lazebnik, Heng Ji, Unnat Jain
                 <br>
-                <em>arXiv preprint, under review</em>
+                <em><strong>International Conference on Learning Representations (ICLR) 2026</strong></em>
                 <br>
                 <a href="https://arxiv.org/pdf/2510.09741">Paper</a> |
                 <a href="https://dwipddalal.github.io/Attwarp/">Project Page</a>

--- a/modern/index.html
+++ b/modern/index.html
@@ -1306,7 +1306,7 @@
                     <img src="../CityNav.png" alt="CityNav">
                 </div>
                 <div class="publication-content">
-                    <div class="publication-venue">EACL 2026 | Oral</div>
+                    <div class="publication-venue">European Chapter of the Association for Computational Linguistics (EACL) 2026 | Oral</div>
                     <h3 class="publication-title">City Navigation in the Wild: Exploring Emergent Navigation from Web-Scale Knowledge in MLLMs</h3>
                     <p class="publication-authors">Dwip Dalal*, <strong>Utkarsh Mishra*</strong>, Nebojsa Jojic, Narendra Ahuja</p>
                     <p class="publication-description">An autonomous navigation system that visually analyzes Street View imagery to determine navigation decisions using purely visual information, incorporating memory-based reasoning and iterative self-improvement.</p>
@@ -1322,7 +1322,7 @@
                     <video src="../Attwarp_Vid1_cropped.mp4" autoplay loop muted playsinline></video>
                 </div>
                 <div class="publication-content">
-                    <div class="publication-venue">Under Review</div>
+                    <div class="publication-venue">International Conference on Learning Representations (ICLR) 2026</div>
                     <h3 class="publication-title">Constructive Distortion: Multimodal LLMs with Query-Aware Image Warping</h3>
                     <p class="publication-authors">D. Dalal, G. Vashishtha, <strong>Utkarsh Mishra</strong>, J. Kim, M. Kanda, H. Ha, S. Lazebnik, H. Ji, U. Jain</p>
                     <p class="publication-description">A query-aware image warping technique "Att-warp" that increases semantically relevant content using an MLLM's own query conditioned attention map. Achieved SOTA on TextVQA, GQA, MMMU, POPE, and DocVQA.</p>


### PR DESCRIPTION
## Summary
Updated publication information across all portfolio pages to reflect full conference names and recent paper acceptances.

## Key Changes
- **EACL 2026**: Expanded abbreviation to full name "European Chapter of the Association for Computational Linguistics (EACL) 2026" for the "City Navigation in the Wild" paper across all three HTML files
- **ICLR 2026**: Updated "Constructive Distortion: Multimodal LLMs with Query-Aware Image Warping" paper status from "arXiv preprint, under review" to "International Conference on Learning Representations (ICLR) 2026" acceptance across all three HTML files

## Files Modified
- `Utkarsh.html` - Updated 2 publication entries
- `index.html` - Updated 2 publication entries  
- `modern/index.html` - Updated 2 publication venue displays

## Details
These changes reflect the acceptance of the "Constructive Distortion" paper to ICLR 2026 and improve clarity by expanding conference acronyms to their full names throughout the portfolio.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refreshes publication metadata across portfolio pages for accuracy and clarity.
> 
> - Expand `EACL 2026` to `European Chapter of the Association for Computational Linguistics (EACL) 2026` in `Utkarsh.html`, `index.html`, and `modern/index.html`
> - Update `Constructive Distortion` status from `arXiv preprint, under review` to `International Conference on Learning Representations (ICLR) 2026` in all three files
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a43ff2d14973cb1b7bd167255803d57ca458799. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->